### PR TITLE
Correct an eslint rule, ensure dependency is installed

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,7 @@
 {
   "extends": "airbnb/base",
-  "parser": "babel-eslint"
+  "parser": "babel-eslint",
+  "rules": {
+    "arrow-parens": [2, "as-needed"]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "babel-eslint": "^6.1.2",
     "eslint": "^3.5.0",
+    "eslint-config-airbnb": "^11.1.0",
     "eslint-plugin-import": "^1.14.0"
   }
 }

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -47,7 +47,7 @@ const install = (plugin, outputDir) => new Promise(resolve => {
     // download, install, and update configs
     downloadPackage(plugin, outputDir).then(output => {
       const installProcess = spawn('npm', ['install', '--prefix', output]);
-      installProcess.on('close', (code) => {
+      installProcess.on('close', code => {
         if (!code) {
           plugins.push(plugin);
           config.set('plugins', plugins);


### PR DESCRIPTION
This PR fixes the following:

- `airbnb` eslint rule is to be installed
- makes an exception (hopefully the last one) that parenthesis is __as-needed__
- correct code accordingly