### PR TITLE
better tests

### DIFF
--- a/__mocks__/.eslintrc
+++ b/__mocks__/.eslintrc
@@ -1,5 +1,8 @@
 {
   "env": {
     "jest": true
+  },
+  "rules": {
+      "no-underscore-dangle": 0
   }
 }

--- a/__mocks__/child_process.js
+++ b/__mocks__/child_process.js
@@ -12,7 +12,6 @@ let mockCode = null;
  *
  * @param {String} code
  */
-// eslint-disable-next-line no-underscore-dangle
 const __setCode = (code) => {
   mockCode = code;
 };
@@ -30,7 +29,6 @@ const spawn = (command, args) => {
   return mockProcess;
 };
 
-// eslint-disable-next-line no-underscore-dangle
 cp.__setCode = __setCode;
 cp.spawn = spawn;
 

--- a/__mocks__/conf.js
+++ b/__mocks__/conf.js
@@ -1,10 +1,12 @@
 // Mocks the module "conf"
 const path = require('path');
 
+let cwdMock = '';
+
 const Conf = class {
   constructor(opts) {
     const o = Object.assign({}, opts);
-    o.cwd = '/jest/conf/path';
+    o.cwd = cwdMock;
     this.store = {};
     this.path = path.resolve(o.cwd);
   }
@@ -16,6 +18,10 @@ const Conf = class {
   set(key, value) {
     this.store[key] = value;
   }
+};
+
+Conf.__setCwd = (cwd) => {
+  cwdMock = cwd;
 };
 
 module.exports = Conf;

--- a/__mocks__/fs.js
+++ b/__mocks__/fs.js
@@ -1,5 +1,6 @@
 const fs = jest.genMockFromModule('fs');
 
+// Mocks fs.link
 fs.link = (src, dest, callback) => {
   callback.call(null);
 };

--- a/__mocks__/http.js
+++ b/__mocks__/http.js
@@ -12,7 +12,6 @@ let mockData = null;
  *
  * @param {String} data
  */
-// eslint-disable-next-line no-underscore-dangle
 const __setMockResponse = (data) => {
   mockData = data;
 };
@@ -30,7 +29,6 @@ const get = (url, callback) => {
   callback.call(null, mockResponse);
 };
 
-// eslint-disable-next-line no-underscore-dangle
 http.__setMockResponse = __setMockResponse;
 http.get = get;
 

--- a/__mocks__/npm-name.js
+++ b/__mocks__/npm-name.js
@@ -6,7 +6,6 @@ let mockAvailable = false;
  *
  * @param {Boolean} available
  */
-// eslint-disable-next-line no-underscore-dangle
 const __setAvailable = (available) => {
   mockAvailable = available;
 };
@@ -28,7 +27,6 @@ const npmName = plugin => new Promise((resolve) => {
   });
 });
 
-// eslint-disable-next-line no-underscore-dangle
 npmName.__setAvailable = __setAvailable;
 
 module.exports = npmName;

--- a/__mocks__/rimraf.js
+++ b/__mocks__/rimraf.js
@@ -7,7 +7,6 @@ let mockError = null;
  *
  * @param {String} data
  */
-// eslint-disable-next-line no-underscore-dangle
 const __setError = (error) => {
   mockError = error;
 };
@@ -22,7 +21,6 @@ const rimraf = (dir, callback) => {
   callback.call(null, mockError);
 };
 
-// eslint-disable-next-line no-underscore-dangle
 rimraf.__setError = __setError;
 
 module.exports = rimraf;

--- a/__tests__/.eslintrc
+++ b/__tests__/.eslintrc
@@ -1,5 +1,10 @@
 {
   "env": {
     "jest": true
+  },
+  "rules": {
+    "global-require": 0,
+    "import/newline-after-import": 0,
+    "no-underscore-dangle": 0
   }
 }

--- a/__tests__/api/index.js
+++ b/__tests__/api/index.js
@@ -25,13 +25,11 @@ describe('general api', () => {
 
 describe('validate', () => {
   it('should check for a valid plugin', async () => {
-    // eslint-disable-next-line global-require, no-underscore-dangle
     require('npm-name').__setAvailable(false);
     expect(await api.checkOnNpm('SHOULD_NOT_EXIST')).toBeFalsy();
   });
 
   it('should check for an invalid plugin', async () => {
-    // eslint-disable-next-line global-require, no-underscore-dangle
     require('npm-name').__setAvailable(true);
     expect(await api.checkOnNpm('SHOULD_EXIST')).toBeTruthy();
   });
@@ -51,13 +49,10 @@ describe('plugins', () => {
     },
   };
 
-  // eslint-disable-next-line global-require, no-underscore-dangle
   require('http').__setMockResponse(JSON.stringify(mockResponse));
-  // eslint-disable-next-line global-require, no-underscore-dangle
   require('npm-name').__setAvailable(true);
 
   it('should fail to install a plugin on download', async () => {
-    // eslint-disable-next-line global-require, no-underscore-dangle
     require('child_process').__setCode(true);
     try {
       await api.install('SHOULD_EXIST', '/jest/test');
@@ -67,7 +62,6 @@ describe('plugins', () => {
   });
 
   it('should install a plugin', async () => {
-    // eslint-disable-next-line global-require, no-underscore-dangle
     require('child_process').__setCode(null);
     await api.install('SHOULD_EXIST', '/jest/test');
     expect(await api.plugins.getAll()).toContain('SHOULD_EXIST');
@@ -82,7 +76,6 @@ describe('plugins', () => {
   });
 
   it('should install a plugin that doesn\'t exist', async () => {
-    // eslint-disable-next-line global-require, no-underscore-dangle
     require('npm-name').__setAvailable(false);
     try {
       await api.install('SHOULD_NOT_EXIST', '/jest/test');
@@ -92,7 +85,6 @@ describe('plugins', () => {
   });
 
   it('should fail to uninstall a plugin', async () => {
-    // eslint-disable-next-line global-require, no-underscore-dangle
     require('rimraf').__setError(true);
     try {
       await api.uninstall('SHOULD_EXIST', '/jest/test');
@@ -102,14 +94,12 @@ describe('plugins', () => {
   });
 
   it('should uninstall a plugin', async () => {
-    // eslint-disable-next-line global-require, no-underscore-dangle
     require('rimraf').__setError(false);
     await api.uninstall('SHOULD_EXIST', '/jest/test');
     expect(await api.plugins.getAll()).not.toContain('SHOULD_EXIST');
   });
 
   it('should uninstall a plugin that doesn\'t exist', async () => {
-    // eslint-disable-next-line global-require, no-underscore-dangle
     require('npm-name').__setAvailable(false);
     try {
       await api.uninstall('INVALID_MODULE', '/jest/test');

--- a/__tests__/utils/conf.js
+++ b/__tests__/utils/conf.js
@@ -1,7 +1,9 @@
+import path from 'path';
 import Conf from '../../src/utils/conf';
 
 describe('conf', () => {
   it('should create a new Conf file', () => {
-    expect(new Conf().path).toEqual('/jest/conf/path');
+    Conf.__setCwd(path.resolve('/', 'jest', 'conf', 'path'));
+    expect(new Conf().path).toEqual(path.resolve('/', 'jest', 'conf', 'path'));
   });
 });

--- a/__tests__/utils/download.js
+++ b/__tests__/utils/download.js
@@ -16,7 +16,6 @@ describe('download', () => {
         },
       },
     };
-    // eslint-disable-next-line global-require, no-underscore-dangle
     require('http').__setMockResponse(JSON.stringify(mockResponse));
     const pkg = 'foobar';
     const outputDir = '/path/to/output';

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Utility modules shared between Dext and Dext Package Manager.",
   "main": "src/index.js",
   "scripts": {
-    "lint": "eslint src",
+    "lint": "eslint __mocks__ __tests__ src",
     "test": "jest --coverage"
   },
   "author": "Vu Tran <vu@vu-tran.com>",


### PR DESCRIPTION
- Moves ignored linting rules to `.eslintrc` file
- Added method to mock the `cwd` for `conf` module
- Update `conf` test to work with Windows environment