### PR TITLE
Add option for debugging during install

### DIFF
--- a/__mocks__/child_process.js
+++ b/__mocks__/child_process.js
@@ -6,6 +6,7 @@ const MockChildProcess = class extends EventEmitter {};
 
 // create a mock process and return code
 let mockCode = null;
+let processShouldError = false;
 
 /**
  * Sets the mock code
@@ -17,19 +18,36 @@ const __setCode = (code) => {
 };
 
 /**
+ * Set to true if the process should send an error message.
+ *
+ * @param {Boolean} flag
+ */
+const __setProcessShouldError = (flag) => {
+  processShouldError = flag;
+};
+
+/**
  * Mock function to override child_process.spawn
  *
  * @param {String} command
  * @param {Array} args
+ * @param {Object} options
  */
 // eslint-disable-next-line no-unused-vars
-const spawn = (command, args) => {
+const spawn = (command, args, options) => {
   const mockProcess = new MockChildProcess();
-  process.nextTick(() => { mockProcess.emit('close', mockCode); });
+  process.nextTick(() => {
+    if (processShouldError) {
+      mockProcess.emit('error', mockCode);
+    } else {
+      mockProcess.emit('close', mockCode);
+    }
+  });
   return mockProcess;
 };
 
 cp.__setCode = __setCode;
+cp.__setProcessShouldError = __setProcessShouldError;
 cp.spawn = spawn;
 
 module.exports = cp;

--- a/__mocks__/conf.js
+++ b/__mocks__/conf.js
@@ -18,6 +18,10 @@ const Conf = class {
   set(key, value) {
     this.store[key] = value;
   }
+
+  clear() {
+    this.store = {};
+  }
 };
 
 Conf.__setCwd = (cwd) => {

--- a/__tests__/api/index.js
+++ b/__tests__/api/index.js
@@ -65,7 +65,7 @@ describe('plugins', () => {
 
   it('should install a plugin', async () => {
     require('child_process').__setCode(null);
-    await api.install('SHOULD_EXIST', '/jest/test');
+    await api.install('SHOULD_EXIST', '/jest/test', { debug: true });
     expect(await api.plugins.getAll()).toContain('SHOULD_EXIST');
   });
 
@@ -83,6 +83,18 @@ describe('plugins', () => {
       await api.install('SHOULD_NOT_EXIST', '/jest/test');
     } catch (err) {
       expect(err).toBe(ERR_MODULE_NOT_FOUND);
+    }
+  });
+
+  it('should fail to install a plugin', async () => {
+    require('npm-name').__setAvailable(true);
+    const cp = require('child_process');
+    cp.__setCode('SHOULD_HAVE_ERRORED');
+    cp.__setProcessShouldError(true);
+    try {
+      await api.startInstall('SHOULD_EXIST', '/jest/test');
+    } catch (err) {
+      expect(err).toBe('SHOULD_HAVE_ERRORED');
     }
   });
 

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -68,15 +68,20 @@ const install = (plugin, outputDir) => new Promise((resolve, reject) => {
     // download, install, and update configs
     downloadPackage(plugin, outputDir).then((output) => {
       const installProcess = spawn('npm', ['install', '--prefix', output]);
-      installProcess.on('close', (code) => {
-        if (code) {
-          reject(ERR_MODULE_DOWNLOAD_ERROR);
+      installProcess
+        .on('error', (err) => {
+          reject(err);
           return;
-        }
-        // enable the plugin
-        plugins.enable(plugin);
-        resolve();
-      });
+        })
+        .on('close', (code) => {
+          if (code) {
+            reject(ERR_MODULE_DOWNLOAD_ERROR);
+            return;
+          }
+          // enable the plugin
+          plugins.enable(plugin);
+          resolve();
+        });
     });
   });
 });


### PR DESCRIPTION
Add an optional `options` param to the `install()` method to allow for debugging installation processes. All it does for now is pass `stdio` into the running process.