### PR TITLE
added function to get only enabled plugins, and added enabled plugins into the config

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -86,6 +86,7 @@ const startInstall = (plugin, outputDir, options) => new Promise((resolve, rejec
             return;
           }
           // enable the plugin
+          plugins.add(plugin);
           plugins.enable(plugin);
           resolve();
         });
@@ -133,7 +134,7 @@ const uninstall = (plugin, srcDir) => new Promise((resolve, reject) => {
       return;
     }
     // disable the plugin
-    plugins.disable(plugin);
+    plugins.remove(plugin);
     resolve();
   });
 });
@@ -166,7 +167,7 @@ const createSymLink = (plugin, src) => new Promise((resolve) => {
 const removeSymLink = plugin => new Promise((resolve) => {
   const dest = getPluginPath(plugin);
   fs.unlink(dest, () => {
-    plugins.disable(plugin);
+    plugins.remove(plugin);
     resolve({
       destPath: dest,
     });

--- a/src/api/plugins.js
+++ b/src/api/plugins.js
@@ -7,6 +7,7 @@ const { PLUGIN_PATH } = require('../utils/paths');
 const config = new Conf();
 
 const getAll = () => config.get('plugins') || [];
+const getAllEnabled = () => config.get('enabledPlugins') || [];
 
 /**
  * Checks if the plugin is already enabled
@@ -15,7 +16,7 @@ const getAll = () => config.get('plugins') || [];
  * @return {Boolean}
  */
 // eslint-disable-next-line no-bitwise
-const isEnabled = plugin => ~getAll().indexOf(plugin);
+const isEnabled = plugin => ~getAllEnabled().indexOf(plugin);
 
 /**
  * Checks if the plugin is installed
@@ -25,6 +26,19 @@ const isEnabled = plugin => ~getAll().indexOf(plugin);
  */
 const isInstalled = plugin => fs.existsSync(path.resolve(PLUGIN_PATH, plugin));
 
+/*
+ * adds newly installed plugin to the config (doesn't enable or disable it)
+ * 
+ * @param {String} plugin - plugin name
+*/
+const add = (plugin) => {
+  const plugins = getAll();
+  if(plugins.indexOf(plugin) == -1){
+    plugins.push(plugin);
+  }
+  config.set('plugins', plugins);
+}
+
 /**
  * Enables the plugin by adding it to the config
  *
@@ -32,8 +46,14 @@ const isInstalled = plugin => fs.existsSync(path.resolve(PLUGIN_PATH, plugin));
  */
 const enable = (plugin) => {
   const plugins = getAll();
-  plugins.push(plugin);
-  config.set('plugins', plugins);
+  if(plugins.indexOf(plugin) == -1){
+    add(plugin);
+  }
+
+  const enabled = getAllEnabled();
+
+  enabled.push(plugin);
+  config.set('enabledPlugins', enabled);
 };
 
 /**
@@ -42,15 +62,29 @@ const enable = (plugin) => {
  * @param {String} plugin - The plugin name
  */
 const disable = (plugin) => {
-  const plugins = getAll();
+  const plugins = getAllEnabled();
+  plugins.splice(plugins.indexOf(plugin), 1);
+  config.set('enabledPlugins', plugins);
+};
+
+/**
+ * Removes the plugin from both plugin config arrays
+ *
+ * @param {String} plugin - plugin name 
+*/
+const remove = (plugin) => {
+  disable(plugin);
+  plugins = getAll();
   plugins.splice(plugins.indexOf(plugin), 1);
   config.set('plugins', plugins);
-};
+}
 
 module.exports = {
   getAll,
+  getAllEnabled,
   isEnabled,
   isInstalled,
   enable,
   disable,
+  remove
 };

--- a/src/utils/conf.js
+++ b/src/utils/conf.js
@@ -7,6 +7,7 @@ module.exports = class extends Conf {
       defaults: {
         theme: '',
         plugins: [],
+        enabledPlugins: []
       },
     };
     const o = Object.assign({}, opts, defaultOpts);

--- a/src/utils/conf.js
+++ b/src/utils/conf.js
@@ -7,7 +7,7 @@ module.exports = class extends Conf {
       defaults: {
         theme: '',
         plugins: [],
-        enabledPlugins: []
+        enabledPlugins: [],
       },
     };
     const o = Object.assign({}, opts, defaultOpts);


### PR DESCRIPTION
I've created another property called `enabledPlugins` in the config in order to store strictly enabled plugins. When a plugin is disabled it's removed from `enabledPlugins` but not `plugins`. Using this version will unfortunately require changes to dext since I renamed a couple things, but I've gotten it to work and can submit a pull request for that too.  