### PR TITLE
should readdir, not files, add tests

### DIFF
--- a/__mocks__/fs.js
+++ b/__mocks__/fs.js
@@ -1,5 +1,6 @@
 const fs = jest.genMockFromModule('fs');
 
+let _error = null;
 let _files = [];
 
 /**
@@ -9,6 +10,15 @@ let _files = [];
  */
 fs.__setFiles = (files) => {
   _files = files;
+};
+
+/**
+ * Set a return error if necessary
+ *
+ * @param {String}
+ */
+fs.__setError = (error) => {
+  _error = error;
 };
 
 // Mocks fs.link
@@ -28,5 +38,20 @@ fs.unlink = (dest, callback) => {
  * @return {Boolean}
  */
 fs.existsSync = filePath => _files.indexOf(filePath) > -1;
+
+/**
+ * Reads the directory and apply the callback
+ * with the mocked values
+ *
+ * @param {String} directory
+ * @param {Function} callback
+ */
+fs.readdir = (directory, callback) => {
+  if (_error) {
+    callback.call(null, _error);
+  } else {
+    callback.call(null, null, _files);
+  }
+};
 
 module.exports = fs;

--- a/__tests__/api/plugins.js
+++ b/__tests__/api/plugins.js
@@ -5,6 +5,30 @@ import { PLUGIN_PATH } from '../../src/utils/paths';
 jest.mock('fs');
 
 describe('plugins', () => {
+  it('should retrieve all plugins from the file system', async () => {
+    require('fs').__setFiles([
+      '/dext/plugins/foo-plugin',
+      '/dext/plugins/bar-plugin',
+      '/dext/plugins/baz-plugin',
+    ]);
+    expect(await plugins.getAllPlugins())
+      .toEqual([
+        '/dext/plugins/foo-plugin',
+        '/dext/plugins/bar-plugin',
+        '/dext/plugins/baz-plugin',
+      ]);
+  });
+
+  it('should return no plugins', async () => {
+    require('fs').__setError('NO_PLUGINS_FOUND');
+    try {
+      await plugins.getAllPlugins();
+    } catch (err) {
+      expect(err)
+        .toEqual('NO_PLUGINS_FOUND');
+    }
+  });
+
   it('should check if a plugin is installed', () => {
     // eslint-disable-next-line global-require
     require('fs').__setFiles([

--- a/src/api/plugins.js
+++ b/src/api/plugins.js
@@ -6,15 +6,27 @@ const { PLUGIN_PATH } = require('../utils/paths');
 // initialize a new config file
 const config = new Conf();
 
+/**
+ * Retrieve a list of enabled plugins (from the config)
+ *
+ * @return {String[]} - A list of enabled plugins
+ */
 const getAll = () => config.get('plugins') || [];
-const getAllPlugins = () => {
-  return new Promise((resolve, reject) => {
-    fs.readFile(PLUGIN_PATH, (err, data) => {
-      if(err) reject(err);
-      else resolve(data);
-    });
+
+/**
+ * Retrieve all plugins in the file system
+ *
+ * @return {String[]} - A list of plugins found in the plugins directory
+ */
+const getAllPlugins = () => new Promise((resolve, reject) => {
+  fs.readdir(PLUGIN_PATH, (err, data) => {
+    if (err) {
+      reject(err);
+    } else {
+      resolve(data);
+    }
   });
-}
+});
 
 /**
  * Checks if the plugin is already enabled


### PR DESCRIPTION
Found a bug that I missed in the review on #47 which should be using `readdir` instead of `readFile`. I've also cleaned up the formatting of the code a little bit and added the necessary mocks/tests for the new method.