### PR TITLE
Plugin installation working correctly on windows

### DIFF
--- a/__mocks__/fs.js
+++ b/__mocks__/fs.js
@@ -1,5 +1,6 @@
 const fs = jest.genMockFromModule('fs');
 
+let _error = null;
 let _files = [];
 
 /**
@@ -9,6 +10,15 @@ let _files = [];
  */
 fs.__setFiles = (files) => {
   _files = files;
+};
+
+/**
+ * Set a return error if necessary
+ *
+ * @param {String}
+ */
+fs.__setError = (error) => {
+  _error = error;
 };
 
 // Mocks fs.link
@@ -28,5 +38,20 @@ fs.unlink = (dest, callback) => {
  * @return {Boolean}
  */
 fs.existsSync = filePath => _files.indexOf(filePath) > -1;
+
+/**
+ * Reads the directory and apply the callback
+ * with the mocked values
+ *
+ * @param {String} directory
+ * @param {Function} callback
+ */
+fs.readdir = (directory, callback) => {
+  if (_error) {
+    callback.call(null, _error);
+  } else {
+    callback.call(null, null, _files);
+  }
+};
 
 module.exports = fs;

--- a/__tests__/api/plugins.js
+++ b/__tests__/api/plugins.js
@@ -5,6 +5,30 @@ import { PLUGIN_PATH } from '../../src/utils/paths';
 jest.mock('fs');
 
 describe('plugins', () => {
+  it('should retrieve all plugins from the file system', async () => {
+    require('fs').__setFiles([
+      '/dext/plugins/foo-plugin',
+      '/dext/plugins/bar-plugin',
+      '/dext/plugins/baz-plugin',
+    ]);
+    expect(await plugins.getAllPlugins())
+      .toEqual([
+        '/dext/plugins/foo-plugin',
+        '/dext/plugins/bar-plugin',
+        '/dext/plugins/baz-plugin',
+      ]);
+  });
+
+  it('should return no plugins', async () => {
+    require('fs').__setError('NO_PLUGINS_FOUND');
+    try {
+      await plugins.getAllPlugins();
+    } catch (err) {
+      expect(err)
+        .toEqual('NO_PLUGINS_FOUND');
+    }
+  });
+
   it('should check if a plugin is installed', () => {
     // eslint-disable-next-line global-require
     require('fs').__setFiles([

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -37,6 +37,20 @@ const search = searchTerm => new Promise((resolve, reject) => {
 });
 
 /**
+  * Updates the config to match the ~/.dext/plugins directory
+  * If current theme is not in the plugin directory, it is set to an empty string
+  */
+const updateConfig = () => new Promise((resolve, reject) => {
+  plugins.fetchPlugins.then((pls) => {
+    config.set('plugins', pls);
+    if(pls.indexOf(config.get('theme')) == -1){
+        config.set('theme', '');
+    }
+    resolve();
+  }, (err) => reject(err));
+});
+
+/**
  * Checks if the plugin/package exists on npm
  *
  * @param {String} plugin - The name of the plugin/package
@@ -228,4 +242,5 @@ module.exports = {
   getTheme,
   getConfig,
   plugins,
+  updateConfig
 };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -84,11 +84,12 @@ const startInstall = (plugin, outputDir, options) => new Promise((resolve, rejec
     downloadPackage(plugin, outputDir).then((output) => {
       const installOptions = {
         stdio: 'ignore',
+        cwd: output
       };
       if (options && options.debug) {
         installOptions.stdio = 'inherit';
       }
-      const installProcess = spawn('npm', ['install', '--prefix', output], installOptions);
+      const installProcess = spawn('npm', ['install'], installOptions);
       installProcess
         .on('error', (err) => {
           reject(err);
@@ -108,7 +109,7 @@ const startInstall = (plugin, outputDir, options) => new Promise((resolve, rejec
 });
 
 /**
- * Installs and enabled a plugin/package and saves it to the given directory
+ * Installs and enables a plugin/package and saves it to the given directory
  *
  * @param {String} plugin - The name of the plugin/package
  * @param {String} outputDir - The directory to install the plugin/package

--- a/src/api/plugins.js
+++ b/src/api/plugins.js
@@ -18,12 +18,13 @@ const getAll = () => config.get('plugins') || [];
  *
  * @return {String[]} - A list of plugins found in the plugins directory
  */
-const getAllPlugins = () => new Promise((resolve, reject) => {
-  fs.readdir(PLUGIN_PATH, (err, data) => {
+const fetchPlugins = () => new Promise((resolve, reject) => {
+  fs.readdir(PLUGIN_PATH, (err, files) => {
     if (err) {
       reject(err);
     } else {
-      resolve(data);
+      files = files.filter((file) => fs.statSync(path.join(paths.PLUGIN_PATH, file)).isDirectory());
+      resolve(files);
     }
   });
 });
@@ -69,7 +70,7 @@ const disable = (plugin) => {
 
 module.exports = {
   getAll,
-  getAllPlugins,
+  fetchPlugins,
   isEnabled,
   isInstalled,
   enable,

--- a/src/api/plugins.js
+++ b/src/api/plugins.js
@@ -6,15 +6,27 @@ const { PLUGIN_PATH } = require('../utils/paths');
 // initialize a new config file
 const config = new Conf();
 
+/**
+ * Retrieve a list of enabled plugins (from the config)
+ *
+ * @return {String[]} - A list of enabled plugins
+ */
 const getAll = () => config.get('plugins') || [];
-const getAllPlugins = () => {
-  return new Promise((resolve, reject) => {
-    fs.readFile(PLUGIN_PATH, (err, data) => {
-      if(err) reject(err);
-      else resolve(data);
-    });
+
+/**
+ * Retrieve all plugins in the file system
+ *
+ * @return {String[]} - A list of plugins found in the plugins directory
+ */
+const getAllPlugins = () => new Promise((resolve, reject) => {
+  fs.readdir(PLUGIN_PATH, (err, data) => {
+    if (err) {
+      reject(err);
+    } else {
+      resolve(data);
+    }
   });
-}
+});
 
 /**
  * Checks if the plugin is already enabled

--- a/src/api/plugins.js
+++ b/src/api/plugins.js
@@ -7,6 +7,14 @@ const { PLUGIN_PATH } = require('../utils/paths');
 const config = new Conf();
 
 const getAll = () => config.get('plugins') || [];
+const getAllPlugins = () => {
+  return new Promise((resolve, reject) => {
+    fs.readFile(PLUGIN_PATH, (err, data) => {
+      if(err) reject(err);
+      else resolve(data);
+    });
+  });
+}
 
 /**
  * Checks if the plugin is already enabled
@@ -49,6 +57,7 @@ const disable = (plugin) => {
 
 module.exports = {
   getAll,
+  getAllPlugins,
   isEnabled,
   isInstalled,
   enable,


### PR DESCRIPTION
On windows, the process for `npm install`ing plugins `npm install`s the directory that dext-core-utils is run in into the `node_modules` directory of the plugin instead of just `npm install`ing the plugin. The fix was using `npm install` instead of `npm install --prefix <directory>` and just changing the working directory in the install options. Not sure why the previous command worked on osx and not windows, but this fixed it and should also still work with osx. 