### PR TITLE
refactor(paths): change path for `themes`

### DIFF
--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -3,13 +3,17 @@ const path = require('path');
 
 exports.USER_PATH = os.homedir();
 exports.DEXT_PATH = path.resolve(exports.USER_PATH, '.dext');
-exports.THEME_PATH = path.resolve(exports.DEXT_PATH, 'plugins');
+exports.THEME_PATH = path.resolve(exports.DEXT_PATH, 'themes');
 exports.PLUGIN_PATH = path.resolve(exports.DEXT_PATH, 'plugins');
 
 /**
- * Retrieve the path to the plugin
- *
  * @param {String} plugin - The name of the plugin/package
  * @return {String}
  */
 exports.getPluginPath = plugin => path.resolve(exports.PLUGIN_PATH, plugin);
+
+/**
+ * @param {String} theme - The name of the theme/package
+ * @return {String}
+ */
+exports.getThemePath = theme => path.resolve(exports.THEME_PATH, theme);


### PR DESCRIPTION
breaking change
Let me know which packages besides `dext` itself is affected by this